### PR TITLE
Ensure chat still functions if gamestate doesn't have a Map

### DIFF
--- a/public/javascripts/game.js
+++ b/public/javascripts/game.js
@@ -163,7 +163,11 @@ async function renderPage(gamestate, force){
             }
         });
 
-        currentAreas = gamestate.map.filter(area => {return _.has(area, 'meeting'); });
+        if (gamestate.map) {
+            currentAreas = gamestate.map.filter(area => {return _.has(area, 'meeting'); });
+        } else {
+            currentAreas = {};
+        }
 
         prepImageMap();
         if (gamestate.chatSidebar){


### PR DESCRIPTION
this fixes the exception raised (In the browser) when trying to access filter on gamestate.map when it's undefined. 